### PR TITLE
Refactor data structures

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -70,7 +70,7 @@ typedef struct s_textures
 	unsigned long		hex_ceiling;
 } 						t_textures;
 
-typedef struct s_map
+typedef struct s_mapinfo
 {
 	int			fd;
 	int			line_count;
@@ -82,7 +82,14 @@ typedef struct s_map
 	char		p_direction;
 	int			p_x;
 	int			p_y;
-}				t_map;
+}				t_mapinfo;
+
+typedef struct s_player
+{
+	char	direction;
+	int		x;
+	int		y;
+}			t_player;
 
 typedef struct s_data
 {
@@ -90,8 +97,10 @@ typedef struct s_data
 	void		*win;
 	int			win_height;
 	int			win_width;
+	t_player	player;
 	t_textures	textures;
-	t_map		map;
+	char		**map;
+	t_mapinfo	mapinfo;
 	t_img		img;
 	int			pixel;
 }				t_data;
@@ -132,11 +141,11 @@ t_ulong	convert_rgb_to_hex(int *rgb_tab);
 int		check_textures_validity(t_textures *textures);
 
 
-int		check_map_validity(t_map *map, char **map_tab);
+int		check_map_validity(t_data *data, char **map_tab);
 
 
 int		check_top_or_bottom(char **map_tab, int i, int j);
-int		check_map_sides(t_map *map, char **map_tab);
+int		check_map_sides(t_mapinfo *map, char **map_tab);
 int		check_left_side_is_closed(char **map_tab);
 int		check_right_side_is_closed(char **map_tab);
 
@@ -150,7 +159,7 @@ void	init_data(t_data *data);
 
 int		is_a_white_space(char c);
 int		print_error(char *str);
-size_t	find_biggest_len(t_map *map, int i);
+size_t	find_biggest_len(t_mapinfo *map, int i);
 int		skip_walls(char **map_tab);
 
 /* debug.c */

--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -76,12 +76,9 @@ typedef struct s_mapinfo
 	int			line_count;
 	char		*path;
 	char		**file;
-	int			nb_line;
-	char		**map;
+	int			height;
+	int			width;
 	int			index_end_of_map;
-	char		p_direction;
-	int			p_x;
-	int			p_y;
 }				t_mapinfo;
 
 typedef struct s_player

--- a/sources/check_map.c
+++ b/sources/check_map.c
@@ -98,7 +98,7 @@ static int	check_map_is_at_the_end(t_mapinfo *map)
 
 int	check_map_validity(t_data *data, char **map_tab)
 {
-	if (data->mapinfo.nb_line < 3)
+	if (data->mapinfo.height < 3)
 		return (print_error("The map should be at least 3 lines long."));
 	if (check_map_elements(data, map_tab) == FAILURE)
 		return (FAILURE);

--- a/sources/check_map.c
+++ b/sources/check_map.c
@@ -1,27 +1,27 @@
 #include "cub3d.h"
 
-static int	check_map_elements(t_map *map, char **map_tab)
+static int	check_map_elements(t_data *data, char **map_tab)
 {
 	int	i;
 	int	j;
 
 	i = 0;
-	map->p_direction = '0';
+	data->player.direction = '0';
 	while (map_tab[i] != NULL)
 	{
 		j = 0;
 		while (map_tab[i][j])
 		{
-			while (map->map[i][j] == ' ' || map->map[i][j] == '\t'
-			|| map->map[i][j] == '\r'
-			|| map->map[i][j] == '\v' || map->map[i][j] == '\f')
+			while (data->map[i][j] == ' ' || data->map[i][j] == '\t'
+			|| data->map[i][j] == '\r'
+			|| data->map[i][j] == '\v' || data->map[i][j] == '\f')
 				j++;
 			if (!(ft_strchr("10NSEW", map_tab[i][j])))
 				return (print_error("There is an invalid letter in the map"));
-			if (ft_strchr("NSEW", map_tab[i][j]) && map->p_direction != '0')
+			if (ft_strchr("NSEW", map_tab[i][j]) && data->player.direction != '0')
 				return (print_error("There is more than one player in the map"));
-			if (ft_strchr("NSEW", map_tab[i][j]) && map->p_direction == '0')
-				map->p_direction = map_tab[i][j];
+			if (ft_strchr("NSEW", map_tab[i][j]) && data->player.direction == '0')
+				data->player.direction = map_tab[i][j];
 			j++;
 		}
 		i++;
@@ -29,13 +29,13 @@ static int	check_map_elements(t_map *map, char **map_tab)
 	return (SUCCESS);
 }
 
-static int	check_position_is_valid(t_map *map, char **map_tab)
+static int	check_position_is_valid(t_data *data, char **map_tab)
 {
 	int	i;
 	int	j;
 
-	i = map->p_y;
-	j = map->p_x;
+	i = data->player.y;
+	j = data->player.x;
 	if (ft_strlen(map_tab[i - 1]) < (size_t)j
 		|| ft_strlen(map_tab[i + 1]) < (size_t)j
 		|| is_a_white_space(map_tab[i][j - 1]) == SUCCESS
@@ -46,12 +46,12 @@ static int	check_position_is_valid(t_map *map, char **map_tab)
 	return (SUCCESS);
 }
 
-static int	check_player_position(t_map *map, char **map_tab)
+static int	check_player_position(t_data *data, char **map_tab)
 {
 	int	i;
 	int	j;
 
-	if (map->p_direction == '0')
+	if (data->player.direction == '0')
 		return (print_error("The map should have a player_direction"));
 	i = 0;
 	while (map_tab[i])
@@ -61,20 +61,20 @@ static int	check_player_position(t_map *map, char **map_tab)
 		{
 			if (ft_strchr("NSEW", map_tab[i][j]))
 			{
-				map->p_x = j;
-				map->p_y = i;
+				data->player.x = j;
+				data->player.y = i;
 				map_tab[i][j] = '0';
 			}
 			j++;
 		}
 		i++;
 	}
-	if (check_position_is_valid(map, map_tab) == FAILURE)
+	if (check_position_is_valid(data, map_tab) == FAILURE)
 		return (print_error("Player position is invalid"));
 	return (SUCCESS);
 }
 
-static int	check_map_is_at_the_end(t_map *map)
+static int	check_map_is_at_the_end(t_mapinfo *map)
 {
 	int	i;
 	int	j;
@@ -96,21 +96,21 @@ static int	check_map_is_at_the_end(t_map *map)
 	return (SUCCESS);
 }
 
-int	check_map_validity(t_map *map, char **map_tab)
+int	check_map_validity(t_data *data, char **map_tab)
 {
-	if (map->nb_line < 3)
+	if (data->mapinfo.nb_line < 3)
 		return (print_error("The map should be at least 3 lines long."));
-	if (check_map_elements(map, map_tab) == FAILURE)
+	if (check_map_elements(data, map_tab) == FAILURE)
 		return (FAILURE);
-	if (check_map_sides(map, map_tab) == FAILURE)
+	if (check_map_sides(&data->mapinfo, map_tab) == FAILURE)
 		return (print_error("The map must be surrounded by walls"));
 	if (check_left_side_is_closed(map_tab) == FAILURE)
 		return (print_error("The map is not fully closed on the left side"));
 	if (check_right_side_is_closed(map_tab) == FAILURE)
 		return (print_error("The map is not fully closed on the right side"));
-	if (check_player_position(map, map_tab) == FAILURE)
+	if (check_player_position(data, map_tab) == FAILURE)
 		return (FAILURE);
-	if (check_map_is_at_the_end(map) == FAILURE)
+	if (check_map_is_at_the_end(&data->mapinfo) == FAILURE)
 		return (print_error("The map description is not the last element"));
 	return (SUCCESS);
 }

--- a/sources/check_map_borders.c
+++ b/sources/check_map_borders.c
@@ -15,7 +15,7 @@ int	check_top_or_bottom(char **map_tab, int i, int j)
 	return (SUCCESS);
 }
 
-int	check_map_sides(t_map *map, char **map_tab)
+int	check_map_sides(t_mapinfo *map, char **map_tab)
 {
 	int	i;
 	int	j;

--- a/sources/check_map_borders.c
+++ b/sources/check_map_borders.c
@@ -23,7 +23,7 @@ int	check_map_sides(t_mapinfo *map, char **map_tab)
 	if (check_top_or_bottom(map_tab, 0, 0) == FAILURE)
 		return (FAILURE);
 	i = 1;
-	while (i < (map->nb_line - 1))
+	while (i < (map->height - 1))
 	{
 		j = ft_strlen(map_tab[i]) - 1;
 		if (map_tab[i][j] != '1')

--- a/sources/create_game_map.c
+++ b/sources/create_game_map.c
@@ -16,27 +16,27 @@ int	count_map_lines(t_data *data, char **file, int i)
 			break ;
 		i++;
 	}
-	data->map.index_end_of_map = i;
+	data->mapinfo.index_end_of_map = i;
 	return (i - index_value);
 }
 
-int	fill_map_tab(t_map *map, char **map_tab, int index)
+int	fill_map_tab(t_mapinfo *mapinfo, char **map_tab, int index)
 {
 	int		i;
 	int		j;
 	size_t	biggest_len;
 
-	biggest_len = find_biggest_len(map, index);
+	biggest_len = find_biggest_len(mapinfo, index);
 	i = 0;
-	while (i < map->nb_line)
+	while (i < mapinfo->nb_line)
 	{
 		j = 0;
 		map_tab[i] = malloc(sizeof(char) * (biggest_len + 1));
 		if (!map_tab[i])
 			return (FAILURE);
-		while (map->file[index][j] && map->file[index][j] != '\n')
+		while (mapinfo->file[index][j] && mapinfo->file[index][j] != '\n')
 		{
-			map_tab[i][j] = map->file[index][j];
+			map_tab[i][j] = mapinfo->file[index][j];
 			j++;
 		}	
 		while (j < (int)biggest_len)
@@ -50,33 +50,33 @@ int	fill_map_tab(t_map *map, char **map_tab, int index)
 
 int	get_map_info(t_data *data, char **file, int i)
 {
-	data->map.nb_line = count_map_lines(data, file, i);
-	data->map.map = malloc(sizeof(char *) * (data->map.nb_line + 1));
-	if (!data->map.map)
+	data->mapinfo.nb_line = count_map_lines(data, file, i);
+	data->map = malloc(sizeof(char *) * (data->mapinfo.nb_line + 1));
+	if (!data->map)
 		return (FAILURE);
-	if (fill_map_tab(&data->map, data->map.map, i) == FAILURE)
+	if (fill_map_tab(&data->mapinfo, data->map, i) == FAILURE)
 		return (FAILURE);
 	return (SUCCESS);
 }
 
-void	change_space_into_wall(t_map *map)
+void	change_space_into_wall(t_data *data)
 {
 	int	i;
 	int	j;
 
 	i = 0;
-	while (map->map[i])
+	while (data->map[i])
 	{
 		j = 0;
-		while (map->map[i][j] == ' ' || map->map[i][j] == '\t'
-		|| map->map[i][j] == '\r'
-		|| map->map[i][j] == '\v' || map->map[i][j] == '\f')
+		while (data->map[i][j] == ' ' || data->map[i][j] == '\t'
+		|| data->map[i][j] == '\r'
+		|| data->map[i][j] == '\v' || data->map[i][j] == '\f')
 			j++;
-		while (map->map[i][++j])
+		while (data->map[i][++j])
 		{
-			if (map->map[i][j] == ' '
-				&& j != map->map[i][ft_strlen(map->map[i]) - 1])
-				map->map[i][j] = '1';
+			if (data->map[i][j] == ' '
+				&& j != data->map[i][ft_strlen(data->map[i]) - 1])
+				data->map[i][j] = '1';
 		}
 		i++;
 	}
@@ -86,6 +86,6 @@ int	create_map(t_data *data, char **file, int i)
 {
 	if (get_map_info(data, file, i) == FAILURE)
 		return (FAILURE);
-	change_space_into_wall(&data->map);
+	change_space_into_wall(data);
 	return (SUCCESS);
 }

--- a/sources/create_game_map.c
+++ b/sources/create_game_map.c
@@ -24,14 +24,13 @@ int	fill_map_tab(t_mapinfo *mapinfo, char **map_tab, int index)
 {
 	int		i;
 	int		j;
-	size_t	biggest_len;
 
-	biggest_len = find_biggest_len(mapinfo, index);
+	mapinfo->width = find_biggest_len(mapinfo, index);
 	i = 0;
-	while (i < mapinfo->nb_line)
+	while (i < mapinfo->height)
 	{
 		j = 0;
-		map_tab[i] = malloc(sizeof(char) * (biggest_len + 1));
+		map_tab[i] = malloc(sizeof(char) * (mapinfo->width + 1));
 		if (!map_tab[i])
 			return (FAILURE);
 		while (mapinfo->file[index][j] && mapinfo->file[index][j] != '\n')
@@ -39,7 +38,7 @@ int	fill_map_tab(t_mapinfo *mapinfo, char **map_tab, int index)
 			map_tab[i][j] = mapinfo->file[index][j];
 			j++;
 		}	
-		while (j < (int)biggest_len)
+		while (j < mapinfo->width)
 			map_tab[i][j++] = '\0';
 		i++;
 		index++;
@@ -50,8 +49,8 @@ int	fill_map_tab(t_mapinfo *mapinfo, char **map_tab, int index)
 
 int	get_map_info(t_data *data, char **file, int i)
 {
-	data->mapinfo.nb_line = count_map_lines(data, file, i);
-	data->map = malloc(sizeof(char *) * (data->mapinfo.nb_line + 1));
+	data->mapinfo.height = count_map_lines(data, file, i);
+	data->map = malloc(sizeof(char *) * (data->mapinfo.height + 1));
 	if (!data->map)
 		return (FAILURE);
 	if (fill_map_tab(&data->mapinfo, data->map, i) == FAILURE)

--- a/sources/debug/debug.c
+++ b/sources/debug/debug.c
@@ -15,7 +15,8 @@ void	debug_display_map(t_data *data)
 void	debug_display_data(t_data *data)
 {
 	debug_display_map(data);
-	printf("Map nb_line: %d\n", data->mapinfo.nb_line);
+	printf("\nMap height: %d\n", data->mapinfo.height);
+	printf("Map width: %d\n", data->mapinfo.width);
 	printf("\nPlayer position: x = %d, y = %d\n", data->player.x, data->player.y);
 	printf("Player direction: %c\n", data->player.direction);
 	printf("Index end of map: %d\n", data->mapinfo.index_end_of_map);

--- a/sources/debug/debug.c
+++ b/sources/debug/debug.c
@@ -5,9 +5,9 @@ void	debug_display_map(t_data *data)
 	int	i;
 
 	i = 0;
-	while (data->map.map[i])
+	while (data->map[i])
 	{
-		printf("%s\n", data->map.map[i]);
+		printf("%s\n", data->map[i]);
 		i++;
 	}
 }
@@ -15,8 +15,8 @@ void	debug_display_map(t_data *data)
 void	debug_display_data(t_data *data)
 {
 	debug_display_map(data);
-	printf("Map nb_line: %d\n", data->map.nb_line);
-	printf("\nPlayer position: x = %d, y = %d\n", data->map.p_x, data->map.p_y);
-	printf("Player direction: %c\n", data->map.p_direction);
-	printf("Index end of map: %d\n", data->map.index_end_of_map);
+	printf("Map nb_line: %d\n", data->mapinfo.nb_line);
+	printf("\nPlayer position: x = %d, y = %d\n", data->player.x, data->player.y);
+	printf("Player direction: %c\n", data->player.direction);
+	printf("Index end of map: %d\n", data->mapinfo.index_end_of_map);
 }

--- a/sources/free_data.c
+++ b/sources/free_data.c
@@ -33,19 +33,19 @@ static void	free_textures(t_textures *textures)
 		free(textures->ceiling);
 }
 
-static void	free_map(t_map *map)
+static void	free_map(t_data *data)
 {
-	if (map->fd > 0)
-		close(map->fd);
-	if (map->file)
-		free_tab(map->file);
-	if (map->map)
-		free_tab(map->map);
+	if (data->mapinfo.fd > 0)
+		close(data->mapinfo.fd);
+	if (data->mapinfo.file)
+		free_tab(data->mapinfo.file);
+	if (data->map)
+		free_tab(data->map);
 }
 
 int	free_data(t_data *data)
 {
 	free_textures(&data->textures);
-	free_map(&data->map);
+	free_map(data);
 	return (FAILURE);
 }

--- a/sources/init_data.c
+++ b/sources/init_data.c
@@ -10,20 +10,20 @@ void	init_textures(t_textures *textures)
 	textures->ceiling = 0;
 }
 
-void	init_map(t_map *map)
+void	init_mapinfo(t_mapinfo *mapinfo)
 {
-	map->fd = 0;
-	map->path = NULL;
-	map->file = NULL;
-	map->map = NULL;
+	mapinfo->fd = 0;
+	mapinfo->path = NULL;
+	mapinfo->file = NULL;
 }
 
 void	init_data(t_data *data)
 {
-	ft_memset(&data->map, 0, sizeof(t_map));
+	ft_memset(&data->mapinfo, 0, sizeof(t_mapinfo));
 	ft_memset(&data->img, 0, sizeof(t_img));
 	init_textures(&data->textures);
-	init_map(&data->map);
+	data->map = NULL;
+	init_mapinfo(&data->mapinfo);
 	data->win_height = WIN_HEIGHT;
 	data->win_width = WIN_WIDTH;
 }

--- a/sources/main.c
+++ b/sources/main.c
@@ -25,11 +25,11 @@ int main(int ac, char **av)
 	if (check_args(av[1]) == FAILURE)
 		return (print_error(ERR_WRONG_FILE));
 	parse_data(av[1], &data);
-	if (get_file_data(&data, data.map.file) == FAILURE)
+	if (get_file_data(&data, data.mapinfo.file) == FAILURE)
 		return (free_data(&data));
 	if (check_textures_validity(&data.textures) == FAILURE)
 		return (print_error(ERR_INVALID_INFO) && free_data(&data));
-	if (check_map_validity(&data.map, data.map.map) == FAILURE)
+	if (check_map_validity(&data, data.map) == FAILURE)
 		return (print_error(ERR_INVALID_INFO) && free_data(&data));
 	debug_display_data(&data);
 	init_mlx(&data);

--- a/sources/parse_data.c
+++ b/sources/parse_data.c
@@ -28,21 +28,21 @@ static void	fill_tab(int row, int column, int i, t_data *data)
 {
 	char	*line;
 
-	line = get_next_line(data->map.fd);
+	line = get_next_line(data->mapinfo.fd);
 	while (line != NULL)
 	{
-		data->map.file[row] = ft_calloc(ft_strlen(line) + 1, sizeof(char));
-		if (!data->map.file[row])
-			return (free_tab(data->map.file));
+		data->mapinfo.file[row] = ft_calloc(ft_strlen(line) + 1, sizeof(char));
+		if (!data->mapinfo.file[row])
+			return (free_tab(data->mapinfo.file));
 		while (line[i] != '\0')
-			data->map.file[row][column++] = line[i++];
-		data->map.file[row++][column] = '\0';
+			data->mapinfo.file[row][column++] = line[i++];
+		data->mapinfo.file[row++][column] = '\0';
 		column = 0;
 		i = 0;
 		free(line);
-		line = get_next_line(data->map.fd);
+		line = get_next_line(data->mapinfo.fd);
 	}
-	data->map.file[row] = NULL;
+	data->mapinfo.file[row] = NULL;
 }
 
 void	parse_data(char *path, t_data *data)
@@ -54,17 +54,17 @@ void	parse_data(char *path, t_data *data)
 	i = 0;
 	row = 0;
 	column = 0;
-	data->map.line_count = get_number_of_lines(path);
-	data->map.path = path;
-	data->map.file = ft_calloc(data->map.line_count + 1, sizeof(char *));
-	if (!(data->map.file))
+	data->mapinfo.line_count = get_number_of_lines(path);
+	data->mapinfo.path = path;
+	data->mapinfo.file = ft_calloc(data->mapinfo.line_count + 1, sizeof(char *));
+	if (!(data->mapinfo.file))
 		return ;
-	data->map.fd = open(path, O_RDONLY);
-	if (data->map.fd < 0)
+	data->mapinfo.fd = open(path, O_RDONLY);
+	if (data->mapinfo.fd < 0)
 		printf("Error: Couldn't open the file\n");
 	else
 	{
 		fill_tab(row, column, i, data);
-		close(data->map.fd);
+		close(data->mapinfo.fd);
 	}
 }

--- a/sources/utils.c
+++ b/sources/utils.c
@@ -20,7 +20,7 @@ int	print_error(char *str)
 	return (FAILURE);
 }
 
-size_t	find_biggest_len(t_map *map, int i)
+size_t	find_biggest_len(t_mapinfo *map, int i)
 {
 	size_t	biggest_len;
 


### PR DESCRIPTION
- Add new "player" structure to contain player position and direction (e.g. `data->player.x`).

- Move map out of map data structure for ease of access later (`data->map[x][y]` instead of `data->map->map[x][y]`)
- Change `map` data structure name to `mapinfo` (e.g. `data->mapinfo.fd` or `data->mapinfo.width`)
- Store map width and height for future use in `mapinfo` structure.